### PR TITLE
Fix assignment collection when course is in a subdir

### DIFF
--- a/ngshare_exchange/exchange.py
+++ b/ngshare_exchange/exchange.py
@@ -171,10 +171,9 @@ class Exchange(ABCExchange):
             if noclobber and os.path.isfile(dest_path):
                 continue
             # the file could be in a subdirectory, check if directory exists
-            if not os.path.exists(dir_name) and dir_name != '':
-                subdir = os.path.join(dest_dir, dir_name)
-                if not os.path.exists(subdir):
-                    os.makedirs(subdir, exist_ok=True)
+            subdir = os.path.join(dest_dir, dir_name)
+            if not os.path.exists(subdir) and dir_name != '':
+                os.makedirs(subdir, exist_ok=True)
                 dest_path = os.path.join(subdir, file_name)
 
             self.log.info('Decoding: {}'.format(dest_path))


### PR DESCRIPTION
The subdir checking was done incorrectly, relative to the teacher root instead of the root of the course on the teacher's account.

Related to #17 

This issue comes up especially with `.ipynb_checkpoints`, since that directory usually exists on the teacher's account, but not in the assignment directory:

```
Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/nbgrader/utils.py", line 530, in capture_log
    app.start()
  File "/opt/conda/lib/python3.10/site-packages/ngshare_exchange/exchange.py", line 235, in start
    return super(Exchange, self).start()
  File "/opt/conda/lib/python3.10/site-packages/nbgrader/exchange/abc/exchange.py", line 84, in start
    self.copy_files()
  File "/opt/conda/lib/python3.10/site-packages/ngshare_exchange/collect.py", line 148, in copy_files
    self.do_copy(submission['files'], dest_path)
  File "/opt/conda/lib/python3.10/site-packages/ngshare_exchange/collect.py", line 167, in do_copy
    self.decode_dir(src, dest)
  File "/opt/conda/lib/python3.10/site-packages/ngshare_exchange/exchange.py", line 188, in decode_dir
    with open(dest_path, 'wb') as d:
FileNotFoundError: [Errno 2] No such file or directory: '/home/jovyan/submitted/extemp139/Java examen 2022/.ipynb_checkpoints/Robotarm-checkpoint.ipynb'
```

This means ngshare would check that `~/.ipynb_checkpoints` is an existing directory. If not, it creates `~/submitted/extemp139/Java examen 2022/.ipynb_checkpoints`. With this patch, it checks for the correct subdirectory instead.