### PR TITLE
Fix incorrect notbook_id returned by assignment list #24

### DIFF
--- a/ngshare_exchange/course_management.py
+++ b/ngshare_exchange/course_management.py
@@ -7,6 +7,7 @@ import json
 import argparse
 from urllib.parse import quote
 
+
 # https://www.geeksforgeeks.org/print-colors-python-terminal/
 def prRed(skk, exit=True):
     print('\033[91m {}\033[00m'.format(skk))
@@ -83,7 +84,6 @@ def check_status_code(response):
 
 
 def check_message(response):
-
     response = response.json()
     if not response['success']:
         prRed(response['message'])
@@ -460,12 +460,10 @@ def parse_args(argv):
 
 
 def main(argv=None):
-
     argv = argv or sys.argv[1:]
     args = parse_args(argv)
     args.func(args)
 
 
 if __name__ == '__main__':
-
     sys.exit(main())

--- a/ngshare_exchange/exchange.py
+++ b/ngshare_exchange/exchange.py
@@ -21,7 +21,6 @@ import json
 
 
 class Exchange(ABCExchange):
-
     username = (
         os.environ['JUPYTERHUB_USER']
         if 'JUPYTERHUB_USER' in os.environ
@@ -38,7 +37,6 @@ class Exchange(ABCExchange):
 
     @property
     def ngshare_url(self):
-
         if self._ngshare_url:
             return self._ngshare_url
         if 'PROXY_PUBLIC_SERVICE_HOST' in os.environ:
@@ -189,7 +187,7 @@ class Exchange(ABCExchange):
 
     def encode_dir(self, src_dir, ignore=None):
         encoded_files = []
-        for (subdir, dirs, files) in os.walk(src_dir):
+        for subdir, dirs, files in os.walk(src_dir):
             for file_name in files:
                 file_path = subdir + os.sep + file_name
                 data_bytes = open(file_path, 'rb').read()

--- a/ngshare_exchange/list.py
+++ b/ngshare_exchange/list.py
@@ -383,7 +383,7 @@ class ExchangeList(Exchange, ABCExchangeList):
 
             info['notebooks'] = []
             for notebook in notebooks:
-                if self.cached:
+                if self.cached or info['status'] == 'fetched':
                     nb_info = {
                         'notebook_id': os.path.splitext(
                             os.path.split(notebook)[1]
@@ -392,11 +392,6 @@ class ExchangeList(Exchange, ABCExchangeList):
                     }
                 elif self.inbound:
                     nb_info = {'notebook_id': notebook['notebook_id']}
-                elif info['status'] == 'fetched':
-                    nb_info = {
-                        'notebook_id': notebook,
-                        'path': os.path.abspath(notebook),
-                    }
                 else:
                     nb_info = {'notebook_id': notebook}
                 if info['status'] != 'submitted':

--- a/ngshare_exchange/release_assignment.py
+++ b/ngshare_exchange/release_assignment.py
@@ -10,7 +10,6 @@ from .exchange import Exchange
 
 
 class ExchangeReleaseAssignment(Exchange, ABCExchangeReleaseAssignment):
-
     force = Bool(
         False, help='Force overwrite existing files in the exchange.'
     ).tag(config=True)
@@ -44,7 +43,6 @@ class ExchangeReleaseAssignment(Exchange, ABCExchangeReleaseAssignment):
                 self.coursedir.assignment_id,
             )
             if os.path.isdir(source):
-
                 # Looks like the instructor forgot to assign
                 self.fail(
                     'Assignment found in "{}" but not "{}", run `nbgrader generate_assignment` first.'.format(

--- a/ngshare_exchange/tests/test_fetch_feedback.py
+++ b/ngshare_exchange/tests/test_fetch_feedback.py
@@ -12,7 +12,6 @@ from .. import ExchangeFetchFeedback
 
 
 class TestExchangeFetchFeedback(TestExchange):
-
     timestamp = 'some_timestamp'
 
     def _mock_bad_feedback(self):
@@ -70,7 +69,6 @@ class TestExchangeFetchFeedback(TestExchange):
         assignment_id=TestExchange.assignment_id,
         student_id=TestExchange.student_id,
     ):
-
         retvalue = self._new_exchange_object(
             ExchangeFetchFeedback, course_id, assignment_id, student_id
         )
@@ -122,7 +120,6 @@ class TestExchangeFetchFeedback(TestExchange):
             assert issubclass(type(e), ExchangeError)
 
     def test_fetch(self):
-
         # set chache folder
 
         submission_name = '{}+{}+{}'.format(
@@ -150,7 +147,6 @@ class TestExchangeFetchFeedback(TestExchange):
                 assert actual_file.read() == reference_file.read()
 
     def test_fetch_path_includes_course(self):
-
         # set chache folder
 
         submission_name = '{}+{}+{}'.format(

--- a/ngshare_exchange/tests/test_release_feedback.py
+++ b/ngshare_exchange/tests/test_release_feedback.py
@@ -14,7 +14,6 @@ from .. import ExchangeReleaseFeedback
 
 
 class TestExchangeReleaseFeedback(TestExchange):
-
     feedback_file = ''
     timestamp = ''
 


### PR DESCRIPTION
I also added tests for the data returned by the ExchangeList plugin.
Previously, only the stdout output (what is printed on the screen) was tested.
The data returned by the plugin (dictionary of assignment information) is used in the nbgrader assigment_list plugin.
