### PR TITLE
Do not create empty feedback directories

### DIFF
--- a/ngshare_exchange/__init__.py
+++ b/ngshare_exchange/__init__.py
@@ -2,8 +2,10 @@ from .exchange import Exchange
 from .submit import ExchangeSubmit
 from .release_feedback import ExchangeReleaseFeedback
 from .release_assignment import ExchangeReleaseAssignment
+from .release_solution import ExchangeReleaseSolution
 from .fetch_feedback import ExchangeFetchFeedback
 from .fetch_assignment import ExchangeFetchAssignment
+from .fetch_solution import ExchangeFetchSolution
 from .collect import ExchangeCollect
 from .list import ExchangeList
 from .version import __version__
@@ -14,9 +16,11 @@ __all__ = [
     "ExchangeCollect",
     "ExchangeFetchAssignment",
     "ExchangeFetchFeedback",
+    "ExchangeFetchSolution",
     "ExchangeList",
     "ExchangeRelease",
     "ExchangeReleaseAssignment",
     "ExchangeReleaseFeedback",
+    "ExchangeReleaseSolution",
     "configureExchange",
 ]

--- a/ngshare_exchange/configure_exchange.py
+++ b/ngshare_exchange/configure_exchange.py
@@ -1,8 +1,10 @@
 from .exchange import Exchange
 from .fetch_assignment import ExchangeFetchAssignment
 from .fetch_feedback import ExchangeFetchFeedback
+from .fetch_solution import ExchangeFetchSolution
 from .release_assignment import ExchangeReleaseAssignment
 from .release_feedback import ExchangeReleaseFeedback
+from .release_solution import ExchangeReleaseSolution
 from .list import ExchangeList
 from .submit import ExchangeSubmit
 from .collect import ExchangeCollect
@@ -19,8 +21,10 @@ def configureExchange(c, ngshare_url=None):
     c.ExchangeFactory.exchange = Exchange
     c.ExchangeFactory.fetch_assignment = ExchangeFetchAssignment
     c.ExchangeFactory.fetch_feedback = ExchangeFetchFeedback
+    c.ExchangeFactory.fetch_solution = ExchangeFetchSolution
     c.ExchangeFactory.release_assignment = ExchangeReleaseAssignment
     c.ExchangeFactory.release_feedback = ExchangeReleaseFeedback
+    c.ExchangeFactory.release_solution = ExchangeReleaseSolution
     c.ExchangeFactory.list = ExchangeList
     c.ExchangeFactory.submit = ExchangeSubmit
     c.ExchangeFactory.collect = ExchangeCollect

--- a/ngshare_exchange/fetch_feedback.py
+++ b/ngshare_exchange/fetch_feedback.py
@@ -46,16 +46,9 @@ class ExchangeFetchFeedback(Exchange, ABCExchangeFetchFeedback):
             os.path.join(self.assignment_dir, root, 'feedback')
         )
 
-        # check if feedback folder exists
-        if not os.path.exists(self.dest_path):
-            Path(self.dest_path).mkdir(parents=True)
-
     def copy_files(self):
         self.log.info('Fetching feedback from server')
-        if len(self.timestamps) == 0:
-            self.log.warning(
-                'No feedback available to fetch for your submissions'
-            )
+        available = False
 
         for timestamp in self.timestamps:
             params = {'timestamp': timestamp, 'list_only': 'false'}
@@ -68,18 +61,26 @@ class ExchangeFetchFeedback(Exchange, ABCExchangeFetchFeedback):
                 )
                 return
             try:
-                dest_with_timestamp = os.path.join(
-                    self.dest_path, str(timestamp)
-                )
-                self.decode_dir(response['files'], dest_with_timestamp)
-                self.log.info(
-                    'Successfully decoded feedback for {} saved to {}'.format(
-                        self.coursedir.assignment_id, dest_with_timestamp
+                files = response['files']
+                if files:
+                    available = True
+                    dest_with_timestamp = os.path.join(
+                        self.dest_path, str(timestamp)
                     )
-                )
+                    self.decode_dir(files, dest_with_timestamp)
+                    self.log.info(
+                        'Successfully decoded feedback for {} saved to {}'.format(
+                            self.coursedir.assignment_id, dest_with_timestamp
+                        )
+                    )
             except:
                 self.log.warning(
                     'Could not decode feedback for timestamp {}'.format(
                         str(timestamp)
                     )
                 )
+
+        if not available:
+            self.log.warning(
+                'No feedback available to fetch for your submissions'
+            )

--- a/ngshare_exchange/fetch_solution.py
+++ b/ngshare_exchange/fetch_solution.py
@@ -28,13 +28,20 @@ class ExchangeFetchSolution(Exchange, ABCExchangeFetchSolution):
             )
         else:
             root = self.coursedir.assignment_id
+        assignment_root = os.path.join(self.assignment_dir, root)
+        if not os.path.isdir(assignment_root):
+            self.fail(
+                'Assignment "{}" was not downloaded, run `nbgrader fetch_assignment` first.'.format(
+                    self.coursedir.assignment_id
+                )
+            )
         self.dest_path = os.path.abspath(
-            os.path.join(self.assignment_dir, root, 'solution')
+            os.path.join(assignment_root, 'solution')
         )
 
-        # check if feedback folder exists
+        # check if solution folder exists
         if not os.path.exists(self.dest_path):
-            Path(self.dest_path).mkdir(parents=True)
+            Path(self.dest_path).mkdir()
 
     def do_copy(self, files):
         '''Copy the src dir to the dest dir omitting the self.coursedir.ignore globs.'''

--- a/ngshare_exchange/list.py
+++ b/ngshare_exchange/list.py
@@ -353,8 +353,10 @@ class ExchangeList(Exchange, ABCExchangeList):
 
     def format_solution(self, info):
         msg = "{course_id} {assignment_id}".format(**info)
-        if os.path.exists(os.path.join(info['assignment_id'], 'solution')):
+        if info['status'] == "fetched_solution":
             msg += " (already downloaded)"
+        elif info['status'] == "fetch_assignment":
+            msg += " (download assignment!)"
         return msg
 
     def copy_files(self):
@@ -394,8 +396,10 @@ class ExchangeList(Exchange, ABCExchangeList):
                 if os.path.exists(solution_dir):
                     info['status'] = 'fetched_solution'
                     info['path'] = os.path.abspath(solution_dir)
-                else:
+                elif os.path.exists(assignment_dir):
                     info['status'] = 'released_solution'
+                else:
+                    info['status'] = 'fetch_assignment'
             elif os.path.exists(assignment_dir):
                 info['status'] = 'fetched'
                 info['path'] = os.path.abspath(assignment_dir)

--- a/ngshare_exchange/release_solution.py
+++ b/ngshare_exchange/release_solution.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+import os
+
+from traitlets import Bool
+
+from nbgrader.exchange.abc import (
+    ExchangeReleaseSolution as ABCExchangeReleaseSolution,
+)
+from .exchange import Exchange
+
+
+class ExchangeReleaseSolution(Exchange, ABCExchangeReleaseSolution):
+    def init_src(self):
+        self.src_path = self.coursedir.format_path(
+            self.coursedir.solution_directory, '.', self.coursedir.assignment_id
+        )
+
+        if not os.path.isdir(self.src_path):
+            source = self.coursedir.format_path(
+                self.coursedir.source_directory,
+                '.',
+                self.coursedir.assignment_id,
+            )
+            if os.path.isdir(source):
+                self.fail(
+                    'Assignment "{}" has no solution "{}", run `nbgrader generate_solution` first.'.format(
+                        source, self.src_path
+                    )
+                )
+            else:
+                self._assignment_not_found(
+                    self.src_path,
+                    self.coursedir.format_path(
+                        self.coursedir.solution_directory, '.', '*'
+                    ),
+                )
+
+    def init_dest(self):
+        if self.coursedir.course_id == '':
+            self.fail('No course id specified. Re-run with --course flag.')
+        self.dest_path = '/solution/{}/{}'.format(
+            self.coursedir.course_id, self.coursedir.assignment_id
+        )
+
+    def solution_exists(self):
+        url = '/solutions/{}'.format(self.coursedir.course_id)
+        response = self.ngshare_api_get(url)
+
+        if response is None:
+            self.log.error(
+                'An error occurred while trying to check if the solution exists {}.'.format(
+                    self.coursedir.course_id
+                )
+            )
+            return True
+
+        if self.coursedir.assignment_id in response['solutions']:
+            if self.force:
+                self.log.info(
+                    'Overwriting solution: {} {}'.format(
+                        self.coursedir.course_id, self.coursedir.assignment_id
+                    )
+                )
+                delete_url = '/solution/{}/{}'.format(
+                    self.coursedir.course_id, self.coursedir.assignment_id
+                )
+                response = self.ngshare_api_delete(delete_url)
+                if response is None:
+                    self.fail(
+                        'An error occurred while trying to delete solution {}'.format(
+                            self.coursedir.assignment_id
+                        )
+                    )
+            else:
+                self.fail(
+                    'Solution already exists, add --force to overwrite: {} {}'.format(
+                        self.coursedir.course_id, self.coursedir.assignment_id
+                    )
+                )
+
+        return False
+
+    def copy_files(self):
+        if not self.solution_exists():
+            self.log.info('Encoding files')
+            data = self.encode_dir(self.src_path)
+            response = self.ngshare_api_post(self.dest_path, data)
+            if response is None:
+                self.log.warning(
+                    'An error occurred while trying to release solution {}'.format(
+                        self.coursedir.assignment_id
+                    )
+                )
+            else:
+                self.log.info(
+                    'Successfully released solution {}'.format(
+                        self.coursedir.assignment_id
+                    )
+                )

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     install_requires=[
         'rapidfuzz',
         'traitlets',
-        'jupyter_core<4.11.2',
+        'jupyter_core<5.0.0',
         'nbgrader>=0.7.0',
     ],
     entry_points={


### PR DESCRIPTION
This PR fixes #26.

This changes the behaviour of `nbgrader fetch_feedback <assignment_id>` when there are no feedback files for a particular  submission. In this case no feedback directory for this submission is created. Previously the empty directory was created. 

A new test is added for this scenario.